### PR TITLE
update github action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,6 @@ runs:
   - uses: fjogeleit/yaml-update-action@main
     with:
       branch: ${{ inputs.gitops-repo-branch }}
-      targetBranch: ${{ inputs.gitops-repo-branch }} 
       repository: ${{ inputs.gitops-repo }}
       commitChange: true 
       createPR: true 

--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,7 @@ runs:
       value: ${{ inputs.value }}
       masterBranchName: main
       token: ${{ inputs.token }}
+      targetBranch: "gitops-${{ github.sha }}"
       #changes: ${{ inputs.changes-by-file }}
       #  - name: Push changes
       #    shell: bash

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ runs:
       targetBranch: ${{ inputs.gitops-repo-branch }} 
       repository: ${{ inputs.gitops-repo }}
       createPR: true 
-      commitChange: false
+      commitChange: true 
       format: YAML
       message: "Repo ${{ github.event.repository.name }} published ${{ github.event.head_commit.message || github.event.release.tag_name }} by ${{ github.actor.login }}"
       workDir: gitops
@@ -54,11 +54,11 @@ runs:
       propertyPath: ${{ inputs.propertyPath }}
       value: ${{ inputs.value }}
       #changes: ${{ inputs.changes-by-file }}
-  - name: Push changes
-    shell: bash
-    run: |
-      cd gitops
-      git config --global user.email "${{ inputs.commit-email }}"
-      git config --global user.name "${{ inputs.commit-name }}"
-      git commit -am "${{ github.event.head_commit.message }}"
-      git push
+      #  - name: Push changes
+      #    shell: bash
+      #    run: |
+      #      cd gitops
+      #      git config --global user.email "${{ inputs.commit-email }}"
+      #      git config --global user.name "${{ inputs.commit-name }}"
+      #      git commit -am "${{ github.event.head_commit.message }}"
+      #      git push

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,7 @@ runs:
       repository: ${{ inputs.gitops-repo }}
       commitChange: true 
       commitUserEmail: ${{ inputs.commit-email }}
+      commitUserName: ${{ inputs.commit-name }}
       createPR: true 
       format: YAML
       message: "Repo ${{ github.event.repository.name }} published ${{ github.event.head_commit.message || github.event.release.tag_name }} by ${{ github.actor.login }}"

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'Used for updating a gitops repo with new image(s)'
 inputs:
   ssh-key:
     description: 'SSH key that has read/write access to the GitOps repo'
-    required: true
+    required: false 
   gitops-repo:
     description: 'GitOps repo to update'
     required: true
@@ -40,7 +40,7 @@ runs:
     uses: actions/checkout@v4
     with:
       repository: ${{ inputs.gitops-repo }}
-      ssh-key: ${{ inputs.ssh-key }}
+      token: ${{ inputs.token }}
       ref: ${{ inputs.gitops-repo-branch}}
       path: gitops
   - uses: fjogeleit/yaml-update-action@main
@@ -58,12 +58,3 @@ runs:
       masterBranchName: main
       token: ${{ inputs.token }}
       targetBranch: ${{ inputs.gitops-repo-branch }}
-      #changes: ${{ inputs.changes-by-file }}
-      #  - name: Push changes
-      #    shell: bash
-      #    run: |
-      #      cd gitops
-      #      git config --global user.email "${{ inputs.commit-email }}"
-      #      git config --global user.name "${{ inputs.commit-name }}"
-      #      git commit -am "${{ github.event.head_commit.message }}"
-      #      git push

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ runs:
       propertyPath: ${{ inputs.propertyPath }}
       value: ${{ inputs.value }}
       masterBranchName: main
-      token: ${{ input.token }}
+      token: ${{ inputs.token }}
       #changes: ${{ inputs.changes-by-file }}
       #  - name: Push changes
       #    shell: bash

--- a/action.yml
+++ b/action.yml
@@ -58,3 +58,5 @@ runs:
       masterBranchName: main
       token: ${{ inputs.token }}
       targetBranch: ${{ inputs.gitops-repo-branch }}
+      description: "This PR was created by GitOps automation."
+      message: "Update Image Tag to ${{ github.sha }}"

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,7 @@ runs:
       branch: "gitops-${{ github.sha }}"
       repository: ${{ inputs.gitops-repo }}
       commitChange: true 
+      commitUserEmail: ${{ inputs.commit-email }}
       createPR: true 
       format: YAML
       message: "Repo ${{ github.event.repository.name }} published ${{ github.event.head_commit.message || github.event.release.tag_name }} by ${{ github.actor.login }}"

--- a/action.yml
+++ b/action.yml
@@ -45,8 +45,8 @@ runs:
       branch: ${{ inputs.gitops-repo-branch }}
       targetBranch: ${{ inputs.gitops-repo-branch }} 
       repository: ${{ inputs.gitops-repo }}
-      createPR: true 
-      commitChange: true 
+      createPR: false 
+      commitChange: false 
       format: YAML
       message: "Repo ${{ github.event.repository.name }} published ${{ github.event.head_commit.message || github.event.release.tag_name }} by ${{ github.actor.login }}"
       workDir: gitops
@@ -54,11 +54,11 @@ runs:
       propertyPath: ${{ inputs.propertyPath }}
       value: ${{ inputs.value }}
       #changes: ${{ inputs.changes-by-file }}
-      #  - name: Push changes
-      #    shell: bash
-      #    run: |
-      #      cd gitops
-      #      git config --global user.email "${{ inputs.commit-email }}"
-      #      git config --global user.name "${{ inputs.commit-name }}"
-      #      git commit -am "${{ github.event.head_commit.message }}"
-      #      git push
+  - name: Push changes
+    shell: bash
+    run: |
+      cd gitops
+      git config --global user.email "${{ inputs.commit-email }}"
+      git config --global user.name "${{ inputs.commit-name }}"
+      git commit -am "${{ github.event.head_commit.message }}"
+      git push

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,13 @@ inputs:
     default: 'main'
   changes-by-file:
     description: 'JSON object with changes to make, by file as key'
-    required: true
+    required: false 
+  valueFile: 
+    description: 'Path to the values files' 
+    required: false
+  propertyPath: 
+    description: 'Path inside the file to the property to patch'
+    required: false
   commit-email:
     description: 'Email address to use for the commit'
     required: true
@@ -41,7 +47,9 @@ runs:
       format: YAML
       message: "Repo ${{ github.event.repository.name }} published ${{ github.event.head_commit.message || github.event.release.tag_name }} by ${{ github.actor.login }}"
       workDir: gitops
-      changes: ${{ inputs.changes-by-file }}
+      valueFile: ${{ inputs.valueFile }}
+      propertyPath: ${{ inputs.propertyPath }}
+      #changes: ${{ inputs.changes-by-file }}
       #- name: Push changes
       #  shell: bash
       #  run: |

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
       token: ${{ inputs.token }}
       ref: ${{ inputs.gitops-repo-branch}}
       path: gitops
-  - uses: fjogeleit/yaml-update-action@main
+  - uses: fjogeleit/yaml-update-action@v0.16.0
     with:
       branch: "gitops-${{ github.sha }}"
       repository: ${{ inputs.gitops-repo }}

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
   valueFile: 
     description: 'Path to the values files' 
     required: false
+  value:
+    description: 'Value for the property to change'
+    required: false
   propertyPath: 
     description: 'Path inside the file to the property to patch'
     required: false
@@ -49,6 +52,7 @@ runs:
       workDir: gitops
       valueFile: ${{ inputs.valueFile }}
       propertyPath: ${{ inputs.propertyPath }}
+      value: ${{ inputs.value }}
       #changes: ${{ inputs.changes-by-file }}
       #- name: Push changes
       #  shell: bash

--- a/action.yml
+++ b/action.yml
@@ -59,4 +59,3 @@ runs:
       token: ${{ inputs.token }}
       targetBranch: ${{ inputs.gitops-repo-branch }}
       description: "This PR was created by GitOps automation."
-      message: "Update Image Tag to ${{ github.sha }}"

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
     with:
       repository: ${{ inputs.gitops-repo }}
       ssh-key: ${{ inputs.ssh-key }}
-      ref: $${{ inputs.gitops-repo-branch}}
+      ref: ${{ inputs.gitops-repo-branch}}
       path: gitops
   - uses: fjogeleit/yaml-update-action@main
     with:

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
       branch: ${{ inputs.gitops-repo-branch }}
       targetBranch: ${{ inputs.gitops-repo-branch }} 
       repository: ${{ inputs.gitops-repo }}
-      createPR: false
+      createPR: true 
       commitChange: false
       format: YAML
       message: "Repo ${{ github.event.repository.name }} published ${{ github.event.head_commit.message || github.event.release.tag_name }} by ${{ github.actor.login }}"

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,9 @@ inputs:
   commit-name:
     description: 'Name to use for the commit'
     required: true
+  token:
+    required: false
+    description: 'GitHub AuthToken for PR'
 
 runs:
   using: "composite"
@@ -53,6 +56,8 @@ runs:
       valueFile: ${{ inputs.valueFile }}
       propertyPath: ${{ inputs.propertyPath }}
       value: ${{ inputs.value }}
+      masterBranchName: main
+      token: ${{ input.token }}
       #changes: ${{ inputs.changes-by-file }}
       #  - name: Push changes
       #    shell: bash

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
       path: gitops
   - uses: fjogeleit/yaml-update-action@main
     with:
-      branch: ${{ git.gitops-repo-branch }}
+      branch: ${{ inputs.gitops-repo-branch }}
       targetBranch: ${{ inputs.gitops-repo-branch }} 
       repository: ${{ inputs.gitops-repo }}
       createPR: false

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
       path: gitops
   - uses: fjogeleit/yaml-update-action@main
     with:
-      branch: main 
+      branch: ${{ git.gitops-repo-branch }}
       targetBranch: ${{ inputs.gitops-repo-branch }} 
       repository: ${{ inputs.gitops-repo }}
       createPR: false
@@ -41,11 +41,11 @@ runs:
       message: "Repo ${{ github.event.repository.name }} published ${{ github.event.head_commit.message || github.event.release.tag_name }} by ${{ github.actor.login }}"
       workDir: gitops
       changes: ${{ inputs.changes-by-file }}
-  - name: Push changes
-    shell: bash
-    run: |
-      cd gitops
-      git config --global user.email "${{ inputs.commit-email }}"
-      git config --global user.name "${{ inputs.commit-name }}"
-      git commit -am "${{ github.event.head_commit.message }}"
-      git push
+      #- name: Push changes
+      #  shell: bash
+      #  run: |
+      #    cd gitops
+      #    git config --global user.email "${{ inputs.commit-email }}"
+      #    git config --global user.name "${{ inputs.commit-name }}"
+      #    git commit -am "${{ github.event.head_commit.message }}"
+      #    git push

--- a/action.yml
+++ b/action.yml
@@ -45,8 +45,8 @@ runs:
       branch: ${{ inputs.gitops-repo-branch }}
       targetBranch: ${{ inputs.gitops-repo-branch }} 
       repository: ${{ inputs.gitops-repo }}
-      createPR: false 
-      commitChange: false 
+      commitChange: true 
+      createPR: true 
       format: YAML
       message: "Repo ${{ github.event.repository.name }} published ${{ github.event.head_commit.message || github.event.release.tag_name }} by ${{ github.actor.login }}"
       workDir: gitops
@@ -54,11 +54,11 @@ runs:
       propertyPath: ${{ inputs.propertyPath }}
       value: ${{ inputs.value }}
       #changes: ${{ inputs.changes-by-file }}
-  - name: Push changes
-    shell: bash
-    run: |
-      cd gitops
-      git config --global user.email "${{ inputs.commit-email }}"
-      git config --global user.name "${{ inputs.commit-name }}"
-      git commit -am "${{ github.event.head_commit.message }}"
-      git push
+      #  - name: Push changes
+      #    shell: bash
+      #    run: |
+      #      cd gitops
+      #      git config --global user.email "${{ inputs.commit-email }}"
+      #      git config --global user.name "${{ inputs.commit-name }}"
+      #      git commit -am "${{ github.event.head_commit.message }}"
+      #      git push

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,7 @@ runs:
       repository: ${{ inputs.gitops-repo }}
       createPR: false
       commitChange: false
+      format: YAML
       message: "Repo ${{ github.event.repository.name }} published ${{ github.event.head_commit.message || github.event.release.tag_name }} by ${{ github.actor.login }}"
       workDir: gitops
       changes: ${{ inputs.changes-by-file }}

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
       path: gitops
   - uses: fjogeleit/yaml-update-action@main
     with:
-      branch: ${{ inputs.gitops-repo-branch }}
+      branch: "gitops-${{ github.sha }}"
       repository: ${{ inputs.gitops-repo }}
       commitChange: true 
       createPR: true 
@@ -57,7 +57,7 @@ runs:
       value: ${{ inputs.value }}
       masterBranchName: main
       token: ${{ inputs.token }}
-      targetBranch: "gitops-${{ github.sha }}"
+      targetBranch: ${{ inputs.gitops-repo-branch }}
       #changes: ${{ inputs.changes-by-file }}
       #  - name: Push changes
       #    shell: bash

--- a/action.yml
+++ b/action.yml
@@ -54,11 +54,11 @@ runs:
       propertyPath: ${{ inputs.propertyPath }}
       value: ${{ inputs.value }}
       #changes: ${{ inputs.changes-by-file }}
-      #- name: Push changes
-      #  shell: bash
-      #  run: |
-      #    cd gitops
-      #    git config --global user.email "${{ inputs.commit-email }}"
-      #    git config --global user.name "${{ inputs.commit-name }}"
-      #    git commit -am "${{ github.event.head_commit.message }}"
-      #    git push
+  - name: Push changes
+    shell: bash
+    run: |
+      cd gitops
+      git config --global user.email "${{ inputs.commit-email }}"
+      git config --global user.name "${{ inputs.commit-name }}"
+      git commit -am "${{ github.event.head_commit.message }}"
+      git push


### PR DESCRIPTION
The changes made in this pull request are to the `action.yml` file, which is used for updating a GitOps repository with new images. The key changes include:
* Making the `ssh-key` input optional
* Changing the default branch from `master` to `main`
* Making the `changes-by-file` input optional
* Adding new inputs for `valueFile`, `value`, and `propertyPath`
* Updating the `actions/checkout` step to use version `v4` instead of `v3`
* Adding a new input for `token` to be used for GitHub authentication
* Updating the `fjogeleit/yaml-update-action` step to use version `v0.16.0` instead of `main`
* Enabling the creation of a pull request and committing changes