### PR TITLE
fix: sanitize newlines in PR title to prevent GitHub Actions output errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,18 @@ jobs:
           echo "✗ Expected long message to be trimmed"
           exit 1
         fi
+        
+        # Test newline sanitization
+        RAW_WITH_NEWLINES="Repo test-repo published fix: resolve issue
+        with multi-line commit message
+        that spans multiple lines by testuser"
+        CLEAN_MESSAGE=$(echo "$RAW_WITH_NEWLINES" | tr '\n' ' ' | tr -s ' ')
+        if [[ "$CLEAN_MESSAGE" == *$'\n'* ]]; then
+          echo "✗ Newlines not properly sanitized"
+          exit 1
+        else
+          echo "✓ Newlines sanitized: $CLEAN_MESSAGE"
+        fi
 
   integration-test-dry-run:
     name: Integration Test (Dry Run)

--- a/action.yml
+++ b/action.yml
@@ -48,11 +48,13 @@ runs:
     id: pr-title
     run: |
       RAW_MESSAGE="Repo ${{ github.event.repository.name }} published ${{ github.event.head_commit.message || github.event.release.tag_name }} by ${{ github.actor.login }}"
-      if [ ${#RAW_MESSAGE} -gt 256 ]; then
-        TRIMMED_MESSAGE="${RAW_MESSAGE:0:253}..."
+      # Replace newlines with spaces to ensure valid GitHub Actions output format
+      CLEAN_MESSAGE=$(echo "$RAW_MESSAGE" | tr '\n' ' ' | tr -s ' ')
+      if [ ${#CLEAN_MESSAGE} -gt 256 ]; then
+        TRIMMED_MESSAGE="${CLEAN_MESSAGE:0:253}..."
         echo "title=$TRIMMED_MESSAGE" >> $GITHUB_OUTPUT
       else
-        echo "title=$RAW_MESSAGE" >> $GITHUB_OUTPUT
+        echo "title=$CLEAN_MESSAGE" >> $GITHUB_OUTPUT
       fi
   - uses: fjogeleit/yaml-update-action@v0.16.0
     with:

--- a/test-pr-title.sh
+++ b/test-pr-title.sh
@@ -53,9 +53,35 @@ test_edge_case() {
     fi
 }
 
-# Test case 4: Simulate actual GitHub context
+# Test case 4: Message with newlines (new sanitization feature)
+test_newline_sanitization() {
+    echo "Test 4: Message with newlines sanitization"
+    
+    RAW_MESSAGE="Repo test-repo published fix: resolve issue
+with multi-line commit message
+that spans multiple lines by testuser"
+    
+    # Apply newline sanitization like in action.yml
+    CLEAN_MESSAGE=$(echo "$RAW_MESSAGE" | tr '\n' ' ' | tr -s ' ')
+    
+    if [ ${#CLEAN_MESSAGE} -gt 256 ]; then
+        TRIMMED_MESSAGE="${CLEAN_MESSAGE:0:253}..."
+        echo "✅ Newlines sanitized and trimmed: ${#TRIMMED_MESSAGE} chars"
+        echo "   Message: $TRIMMED_MESSAGE"
+    else
+        echo "✅ Newlines sanitized: $CLEAN_MESSAGE (${#CLEAN_MESSAGE} chars)"
+    fi
+    
+    # Verify no newlines remain
+    if [[ "$CLEAN_MESSAGE" == *$'\n'* ]]; then
+        echo "❌ Newlines still present in cleaned message"
+        return 1
+    fi
+}
+
+# Test case 5: Simulate actual GitHub context
 test_github_context() {
-    echo "Test 4: Simulated GitHub context"
+    echo "Test 5: Simulated GitHub context"
     
     # Simulate GitHub environment variables
     GITHUB_REPOSITORY_NAME="my-awesome-app"
@@ -82,6 +108,8 @@ echo ""
 test_long_message  
 echo ""
 test_edge_case
+echo ""
+test_newline_sanitization
 echo ""
 test_github_context
 


### PR DESCRIPTION

• Fix commit message sanitization to prevent GitHub Actions output errors by replacing newlines with spaces 
• Add comprehensive test coverage for newline sanitization in both GitHub workflow and test script

This change addresses an issue where multi-line commit messages would break GitHub Actions output format, causing workflow failures. The solution sanitizes commit messages by converting newlines to spaces and compressing consecutive spaces before applying the existing length trimming logic.